### PR TITLE
chore(renovate): add matchUpdateTypes to maven automerge rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,7 @@
   packageRules: [
     {
       matchManagers: ["maven"],
+      matchUpdateTypes: ["major", "minor", "patch"],
       automerge: true,
     },
     {


### PR DESCRIPTION
Add explicit `matchUpdateTypes` configuration to the maven package rule
to ensure automerging applies to major, minor, and patch updates.

This makes the automerge behavior more explicit and predictable for
Maven dependency updates.