### PR TITLE
chore(renovate): enable automerge for pyenv manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,10 @@
       automerge: true,
     },
     {
+      matchManagers: ["pyenv"],
+      automerge: true,
+    },
+    {
       matchManagers: ["github-actions"],
       automerge: true,
     },


### PR DESCRIPTION
Add automerge configuration for the pyenv manager in Renovate to automatically merge pyenv-related updates.