### PR TITLE
ci: add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: build
+on:
+  push:
+    branches: ["**"]
+    tags: ["v*"]
+  workflow_call:
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: write
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - &java
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - run: ./mvnw verify --batch-mode --fail-at-end
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}
+
+  full:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - *java
+      - run: ./mvnw clean verify --batch-mode --fail-at-end
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Add a GitHub Actions workflow for continuous integration with two jobs:
- build: runs on push to any branch or tag, executes Maven verify
- full: runs clean verify for comprehensive testing

Both jobs use Ubuntu 24.04, Java 21 Temurin distribution, and
authenticate with GitHub packages using GH_USERNAME and GH_TOKEN.