### PR TITLE
fix(renovate): rebase PRs when behind base branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,8 @@
   timezone: "UTC",
   platformAutomerge: true,
   automergeStrategy: "squash",
+  // Rebase whenever PR falls behind base branch to keep them mergeable
+  rebaseWhen: "behind-base-branch",
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
   // Squash merges break subtree history
   ignorePaths: [".share/**", ".agents/**"],


### PR DESCRIPTION
Add `rebaseWhen: behind-base-branch` to ensure Renovate automatically
rebases its PRs when they become stale (behind the base branch).

This is needed because:
- PRs with automerge enabled need to be up-to-date before merging
- Without this setting, Renovate may not automatically rebase stale PRs
- Branch protection rules often require PRs to be up-to-date

- Add `rebaseWhen: "behind-base-branch"` to renovate.json5