### PR TITLE
fix: correct skill frontmatter violations in java and pull-request skills (#4)

### DIFF
--- a/skills/java/SKILL.md
+++ b/skills/java/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: java
-license: CC-BY-NC-SA-4.0
 description: |
   Write code in the Java programming language.
-  
+
   ALWAYS apply this skill when:
   - Creating or modifying `.java` source files
   - Working with Java classes, interfaces, records, or enums
   - Writing or refactoring Java code of any kind
-# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
-#
-# SPDX-License-Identifier: CC-BY-NC-SA-4.0
 ---
+
+<!--
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
 
 Use for writing Java code in `.java` files.
 

--- a/skills/pull-request/SKILL.md
+++ b/skills/pull-request/SKILL.md
@@ -1,22 +1,19 @@
 ---
 name: pull-request
 description: |
-  ALWAYS use this skill when ANY files are modified, created, or deleted - including fixing bugs, adding features, refactoring, debugging, updating configs/workflows, or investigating issues that result in code changes. Handles committing, pushing, and creating/updating pull requests through GitHub.
-  
-  ALWAYS apply this skill when:
-  - Making changes to files (create, modify, delete)
-  - Adding new features or functionality
-  - Fixing bugs or issues
-  - Refactoring or restructuring code
-  - Updating documentation (README.md, AGENTS.md, skill files)
-  - Changing configuration files or workflows
-  - Any work that results in file modifications
-  
-  This skill MUST be used alongside any domain-specific skills (java, gradle, etc.) when file changes are involved.
-# SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
-#
-# SPDX-License-Identifier: CC-BY-NC-SA-4.0
+  ALWAYS use when files are modified, created, or deleted - including bugs,
+  features, refactoring, or config changes. Handles committing, pushing, and
+  PR management through GitHub.
+
+  Use when: making file changes, adding features, fixing bugs, refactoring,
+  updating docs or configs. Must be used with domain-specific skills.
 ---
+
+<!--
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
 
 **CRITICAL: This skill must ALWAYS be used whenever files are created, modified, or deleted, regardless of what other skills are also being applied.**
 
@@ -189,3 +186,9 @@ Use your AI identity:
 | Claude  | `Claude`         | `claude@anthropic.localhost` |
 
 Place the Co-authored-by trailer at the end of the commit message body, after the description.
+
+---
+
+SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -27,6 +27,23 @@ skill-name/
 **CRITICAL:** Skills are fussy with frontmatter. The `---` must be the very
 first line in the file.
 
+### Frontmatter Fields
+
+Only two fields allowed in frontmatter:
+
+- **`name`**: Skill identifier
+  - Max 64 characters
+  - Lowercase letters, numbers, and hyphens only
+  - Must not start or end with a hyphen
+  - Examples: `java`, `pull-request`, `gradle-shadow`
+
+- **`description`**: When to use this skill (this triggers the skill)
+  - Max 1024 characters, non-empty
+  - Be specific about triggers and usage scenarios
+  - Include "when to use" guidance here, not in the body
+
+Do not include other fields like `license` in frontmatter.
+
 ### Correct Structure
 
 ```markdown


### PR DESCRIPTION
Fix frontmatter issues that violated the skill spec in java and
pull-request skills.

**Problem:**
The java and pull-request skills had frontmatter violations:
- java/SKILL.md had an invalid `license` field (only `name` and
`description` allowed)
- Both skills had SPDX comments inside frontmatter instead of after it
- pull-request/SKILL.md description exceeded 1024 character limit

**Changes:**

- java/SKILL.md: Removed `license` field; moved SPDX comment to proper
location outside frontmatter
- pull-request/SKILL.md: Condensed description to ~330 characters; fixed
SPDX comment placement
- skill-creator/SKILL.md: Added frontmatter validation rules documenting
spec constraints
- AGENTS.md: Added reminder about using `/skill pull-request` when skill
isn't auto-triggered

**Verification:**
All SKILL.md files now conform to the spec:
- `name`: max 64 chars, lowercase/hyphens only, no leading/trailing
hyphen
- `description`: max 1024 chars, non-empty
- Only `name` and `description` fields in frontmatter
- SPDX comments properly placed after frontmatter in HTML comment block

---------

Co-authored-by: Kimi <kimi@moonshot.localhost>