### PR TITLE
refactor: move version strategy classes from internal package to public package

### DIFF
--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/AfterTagHeadStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/AfterTagHeadStrategy.java
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import com.google.common.base.MoreObjects;
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.semver4j.Semver;
@@ -24,13 +22,13 @@ import org.semver4j.Semver;
  *
  * <p>Build metadata includes git distance and short SHA for traceability.</p>
  */
-public final class AfterTagHeadStrategy implements VersionStrategy {
+final class AfterTagHeadStrategy implements VersionStrategy {
 
   private static final String UNKNOWN = "unknown";
 
   private final GitContext ctx;
 
-  public AfterTagHeadStrategy(GitContext ctx) {
+  AfterTagHeadStrategy(GitContext ctx) {
     this.ctx = ctx;
   }
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/AfterTagTopicStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/AfterTagTopicStrategy.java
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import com.google.common.base.MoreObjects;
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.semver4j.Semver;
@@ -28,7 +26,7 @@ import org.semver4j.Semver;
  * <p>The prerelease uses distance from tag (same as HEAD branch would),
  * while metadata uses distance from merge base (commits on topic branch only).</p>
  */
-public final class AfterTagTopicStrategy implements VersionStrategy {
+final class AfterTagTopicStrategy implements VersionStrategy {
 
   private static final String UNKNOWN = "unknown";
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/NoTagHeadStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/NoTagHeadStrategy.java
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import com.google.common.base.MoreObjects;
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import org.semver4j.Semver;
 
 /**
@@ -20,13 +18,13 @@ import org.semver4j.Semver;
  *
  * <p>Starts from 0.0.0 and adds prerelease with total commits and metadata.</p>
  */
-public final class NoTagHeadStrategy implements VersionStrategy {
+final class NoTagHeadStrategy implements VersionStrategy {
 
   private static final String UNKNOWN = "unknown";
 
   private final GitContext ctx;
 
-  public NoTagHeadStrategy(GitContext ctx) {
+  NoTagHeadStrategy(GitContext ctx) {
     this.ctx = ctx;
   }
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/NoTagTopicStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/NoTagTopicStrategy.java
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import com.google.common.base.MoreObjects;
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import org.semver4j.Semver;
 
 /**
@@ -21,12 +19,12 @@ import org.semver4j.Semver;
  *       metadata: 2 commits since <a href="https://git-scm.com/docs/git-merge-base">merge base</a>)</li>
  * </ul>
  */
-public final class NoTagTopicStrategy implements VersionStrategy {
+final class NoTagTopicStrategy implements VersionStrategy {
 
   private static final String UNKNOWN = "unknown";
   private final GitContext ctx;
 
-  public NoTagTopicStrategy(GitContext ctx) {
+  NoTagTopicStrategy(GitContext ctx) {
     this.ctx = ctx;
   }
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/Objects.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/Objects.java
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import org.jspecify.annotations.Nullable;
 
 /**
  * Internal utility class for object operations.
  */
-public final class Objects {
+final class Objects {
 
   private Objects() {}
 
@@ -22,7 +22,7 @@ public final class Objects {
    * @param <T> the type of the value
    * @throws IllegalStateException if value is null
    */
-  public static <T> T requireNonNullElseThrow(@Nullable T value, String message) {
+  static <T> T requireNonNullElseThrow(@Nullable T value, String message) {
     if (value == null) {
       throw new IllegalStateException(message);
     }

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/OnExactTagHeadStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/OnExactTagHeadStrategy.java
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import org.semver4j.Semver;
 
 /**
@@ -20,11 +18,11 @@ import org.semver4j.Semver;
  *
  * <p>This is the cleanest strategy - no prerelease or build metadata needed.</p>
  */
-public final class OnExactTagHeadStrategy implements VersionStrategy {
+final class OnExactTagHeadStrategy implements VersionStrategy {
 
   private final GitContext ctx;
 
-  public OnExactTagHeadStrategy(GitContext ctx) {
+  OnExactTagHeadStrategy(GitContext ctx) {
     this.ctx = ctx;
   }
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/OnExactTagTopicStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/OnExactTagTopicStrategy.java
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
+package com.xenoterracide.semver;
 
 import com.google.common.base.MoreObjects;
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
 import org.semver4j.Semver;
 
 /**
@@ -22,12 +20,12 @@ import org.semver4j.Semver;
  *   <li>v1.0.0 on feature-x (0 new commits) → {@code 1.0.0+branch.feature-x.git.0.abc123}</li>
  * </ul>
  */
-public final class OnExactTagTopicStrategy implements VersionStrategy {
+final class OnExactTagTopicStrategy implements VersionStrategy {
 
   private static final String UNKNOWN = "unknown";
   private final GitContext ctx;
 
-  public OnExactTagTopicStrategy(GitContext ctx) {
+  OnExactTagTopicStrategy(GitContext ctx) {
     this.ctx = ctx;
   }
 

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionCalculator.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionCalculator.java
@@ -5,7 +5,6 @@
 package com.xenoterracide.semver;
 
 import com.xenoterracide.git.GitMetadata;
-import com.xenoterracide.semver.internal.VersionStrategyFactory;
 import java.util.Objects;
 import org.semver4j.Semver;
 
@@ -22,7 +21,7 @@ import org.semver4j.Semver;
  * System.out.println(version); // e.g., "1.0.1-alpha.0.5+git.5.abc123"
  * }</pre>
  */
-public final class VersionCalculator {
+final class VersionCalculator {
 
   private VersionCalculator() {
     // utility class

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionStrategy.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionStrategy.java
@@ -4,12 +4,6 @@
 
 package com.xenoterracide.semver;
 
-import com.xenoterracide.semver.internal.AfterTagHeadStrategy;
-import com.xenoterracide.semver.internal.AfterTagTopicStrategy;
-import com.xenoterracide.semver.internal.NoTagHeadStrategy;
-import com.xenoterracide.semver.internal.NoTagTopicStrategy;
-import com.xenoterracide.semver.internal.OnExactTagHeadStrategy;
-import com.xenoterracide.semver.internal.OnExactTagTopicStrategy;
 import org.semver4j.Semver;
 
 /**

--- a/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionStrategyFactory.java
+++ b/module/semver-calculator/src/main/java/com/xenoterracide/semver/VersionStrategyFactory.java
@@ -2,10 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-package com.xenoterracide.semver.internal;
-
-import com.xenoterracide.semver.GitContext;
-import com.xenoterracide.semver.VersionStrategy;
+package com.xenoterracide.semver;
 
 /**
  * Factory for creating version calculation strategies based on git context.
@@ -16,7 +13,7 @@ import com.xenoterracide.semver.VersionStrategy;
  *   <li>Branch type: HEAD_BRANCH or TOPIC_BRANCH</li>
  * </ul>
  */
-public final class VersionStrategyFactory {
+final class VersionStrategyFactory {
 
   private VersionStrategyFactory() {
     // utility class
@@ -28,7 +25,7 @@ public final class VersionStrategyFactory {
    * @param ctx the git context
    * @return the version strategy for this context
    */
-  public static VersionStrategy determineStrategy(GitContext ctx) {
+  static VersionStrategy determineStrategy(GitContext ctx) {
     var hasTag = ctx.hasTagInHistory();
     var onExactTag = ctx.isOnTagExact();
     var isHeadBranch = ctx.isHeadBranch();


### PR DESCRIPTION
Move all version strategy classes from `com.xenoterracide.semver.internal` to `com.xenoterracide.semver` package.

This change:
- Makes the strategy classes package-private (no longer public)
- Reduces visibility of constructors to package-private
- Removes redundant imports now that classes are in the same package
- Simplifies the overall package structure by eliminating the unnecessary internal subpackage

BREAKING CHANGE: Classes that were previously in the `internal` package are no longer publicly accessible.