### PR TITLE
chore(renovate): change automerge strategy to rebase and enable auto-approve

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,8 @@
   dependencyDashboard: true,
   timezone: "UTC",
   platformAutomerge: true,
-  automergeStrategy: "squash",
+  automergeStrategy: "rebase",
+  autoApprove: true,
   // Rebase whenever PR falls behind base branch to keep them mergeable
   rebaseWhen: "behind-base-branch",
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate


### PR DESCRIPTION
Update Renovate configuration to:
- Change automergeStrategy from "squash" to "rebase"
- Enable autoApprove for automated dependency updates