### PR TITLE
ci(renovate): add branchName template for xenoterracide actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,6 +47,7 @@
       // Only these get digest pins; other actions get normal version tag updates
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
+      branchName: "{{{packageFile}}}-{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
       pinDigests: true,
     },


### PR DESCRIPTION
Add explicit branchName template for xenoterracide GitHub Actions
to ensure unique branch names when pinning digests. This prevents
branch name collisions when multiple actions are updated.
