### PR TITLE
fix(renovate): correct branch naming key from branchName to branchTopic

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,7 +47,7 @@
       // Only these get digest pins; other actions get normal version tag updates
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
-      branchName: "{{{packageFile}}}-{{{depNameSanitized}}}-{{{newDigestShort}}}",
+      branchTopic: "{{{packageFile}}}-{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
       pinDigests: true,
     },


### PR DESCRIPTION
The Renovate configuration was using an incorrect key `branchName` when
it should be `branchTopic` for customizing the branch name template.

This fix ensures that digest updates for xenoterracide GitHub Actions
will use the correct branch naming pattern as intended.