### PR TITLE
ci: add jbang test workflow and simplify lint-staged config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,3 +12,15 @@ jobs:
       actions: write
       contents: read
       packages: read
+  jbang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+      - run: ./mvnw install -DskipTests -q --batch-mode
+      - uses: jbangdev/setup-jbang@main
+      - run: jbang main.java --help
+      - run: jbang main.java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
 #
-# SPDX-License-Identifier: CC0-1.0
 # SPDX-License-Identifier: MIT
 
 name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,6 @@ jobs:
           java-version: "21"
           distribution: "temurin"
       - run: ./mvnw install -DskipTests -q --batch-mode
-      - uses: jbangdev/setup-jbang@main
+      - uses: jbangdev/setup-jbang@v0.1.1
       - run: jbang main.java --help
       - run: jbang main.java

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -16,25 +16,10 @@ const licenseScripts = "--license 'MIT' --fallback-dot-license";
 const withoutYarn = (files) =>
   files.filter((file) => !file.includes("/.yarn/") && !file.startsWith(".yarn/") && !file.endsWith(".pnp.cjs"));
 
-// Exclude .github/**/*.yml from general config pattern (it has its own MIT pattern)
-const withoutGithubYml = (files) => files.filter((file) => !(file.startsWith(".github/") && file.endsWith(".yml")));
-
 const withFiles = (command, files) => `${command} ${files.map((file) => `"${file.replace(/"/g, '\\"')}"`).join(" ")}`;
 
 const run = (commands) => (files) => {
   const filtered = withoutYarn(files);
-
-  if (!filtered.length) {
-    return [];
-  }
-
-  const cmds = Array.isArray(commands) ? commands : [commands];
-  return cmds.map((command) => withFiles(command, filtered));
-};
-
-// For patterns that should exclude .github/**/*.yml (it has its own MIT pattern)
-const runWithoutGithubYml = (commands) => (files) => {
-  const filtered = withoutGithubYml(withoutYarn(files));
 
   if (!filtered.length) {
     return [];
@@ -51,12 +36,9 @@ module.exports = {
   "{.config/git/hooks/**,**/*.*sh}": run([`${reuse} ${copyright} ${symbol} ${licenseScripts} --style python`, shfmt]),
   "*.{md,adoc}": run([`${reuse} ${copyright} ${symbol} ${licenseDocumentation}`, prettier]),
   // Config files - excludes .github/**/*.yml which is handled separately as scripts
-  "*.{xml,yaml,yml,properties,toml,json5}": runWithoutGithubYml([
-    `${reuse} ${copyright} ${licenseConfiguration} ${symbol}`,
-    prettier,
-  ]),
+  "*.{xml,yaml,properties,toml,json5}": run([`${reuse} ${copyright} ${licenseConfiguration} ${symbol}`, prettier]),
   // GitHub workflows contain significant logic
-  ".github/**/*.yml": run([`${reuse} ${copyright} ${symbol} ${licenseScripts}`, prettier]),
+  "*.yml": run([`${reuse} ${copyright} ${symbol} ${licenseScripts}`, prettier]),
   "*.{js,cjs}": run([`${reuse} ${copyright} ${symbol} ${licenseScripts}`, prettier]),
   ".{*ignore,editorconfig,gitattributes,mailmap}": run([
     `${reuse} ${copyright} ${symbol} ${licenseConfiguration}`,


### PR DESCRIPTION
- Add jbang job to build workflow to test jbang integration
- Remove duplicate SPDX-License-Identifier in build.yml
- Simplify lint-staged configuration by removing special handling for .github/**/*.yml
- Change yml pattern from .github/**/*.yml to *.yml for consistency
