### PR TITLE
ci: update Java version from 21 to 25 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "temurin"
       - run: ./mvnw install -DskipTests -q --batch-mode
       - uses: jbangdev/setup-jbang@v0.1.1


### PR DESCRIPTION
Updates the Java version used in the GitHub Actions build workflow
from 21 to 25 to align with the latest LTS release.