### PR TITLE
docs: improve Java assertJ guidance and document workflow limitations (#12)

### DIFF
--- a/skills/java/SKILL.md
+++ b/skills/java/SKILL.md
@@ -265,8 +265,16 @@ assertThat(user)
     .returns(30, User::getAge);
 
 // BEST - hasFieldOrPropertyWithValue with Immutables datatype for fields
-// Immutables generates type-safe string constants: User_.NAME_
-// (accessed via Datatypes_User.User_.NAME_ or just User_.NAME_ if imported)
+// The @Data annotation generates a class named Datatypes_<Type> containing
+// type-safe field name constants. For a User record, this generates Datatypes_User
+// with constants like User_.NAME_ and User_.AGE_.
+//
+// Import the constants for clean usage:
+//   import static com.example.Datatypes_User.User_;
+//
+// This method is preferred because when assertions fail, the error message
+// includes the field name (e.g., "expected field/property 'name' value"),
+// unlike approaches that result in unhelpful messages like "expected:<true> but was:<false>"
 assertThat(user)
     .hasFieldOrPropertyWithValue(User_.NAME_, "Alice")
     .hasFieldOrPropertyWithValue(User_.AGE_, 30);

--- a/skills/session-init/SKILL.md
+++ b/skills/session-init/SKILL.md
@@ -170,6 +170,35 @@ modify files outside your session.
 
 **When uncertain, verify** rather than assuming state is as you left it.
 
+## GitHub Workflow Limitations
+
+AI agents **cannot edit GitHub workflow files** (`.github/workflows/*.yml`). This is a hard limitation — workflow file modifications will fail. Other YAML files (`.yaml`) are not affected.
+
+### Planning Implications
+
+When creating plans that involve workflow changes:
+
+- Identify workflow edits as **human-required tasks**
+- Provide clear instructions for the human to make the changes
+- Structure the plan so AI-managed work can proceed independently
+
+### Example Compensation Strategy
+
+````markdown
+## Plan
+
+1. [AI] Update build configuration
+2. [AI] Add new test cases for the feature
+3. [HUMAN] Update .github/workflows/ci.yml:
+   - Add new job step after "Run Tests":
+     ```yaml
+     - run: <build-tool> integration-test
+     ```
+4. [AI] Update documentation to reflect new CI step
+````
+
+Flag workflow-related changes early so the human can prepare or execute them in parallel.
+
 ---
 
 SPDX-FileCopyrightText: Copyright © 2026 Caleb Cushing


### PR DESCRIPTION
Improve Java skill documentation for better clarity on AssertJ patterns
and document AI limitations for GitHub workflow editing.

**Java Skill Changes:**
- Explain why `hasFieldOrPropertyWithValue` is preferred over
alternatives (better error messages)
- Clarify how to import the generated `Datatypes_<Type>` constants with
explicit static import example

**Session-Init Skill Changes:**
- Document that AI agents cannot edit GitHub workflow files (hard
limitation)
- Provide planning guidance for compensating workflow-related changes
- Include example compensation strategy using [AI] and [HUMAN] task
labels

---------

Co-authored-by: Kimi <kimi@moonshot.localhost>