### PR TITLE
ci(renovate): enable automerge for all github-actions update types

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,7 @@
     },
     {
       matchManagers: ["github-actions"],
+      matchUpdateTypes: ["pin", "digest", "major", "minor", "patch"],
       automerge: true,
       // Expand short tags like @v6 to full version @v6.0.2 without pinning to digests
       rangeStrategy: "pin",


### PR DESCRIPTION
Add explicit matchUpdateTypes configuration to the github-actions
manager to ensure automerge applies to all update types including
pin, digest, major, minor, and patch.
