### PR TITLE
refactor(renovate): simplify GitHub Actions config and remove redundant rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,21 +40,9 @@
     },
     {
       matchManagers: ["github-actions"],
-      automerge: true,
-      // Expand short tags like @v6 to full version @v6.0.2 without pinning to digests
-
       extends: ["helpers:pinGitHubActionDigests"],
-      extractVersion: "^(?<version>v?\\d+\\.\\d+\\.\\d+)$",
-      versioning: "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
-    },
-    {
-      // Pin xenoterracide org actions to commit SHAs for build reproducibility
-      // Only these get digest pins; other actions get normal version tag updates
-      matchManagers: ["github-actions"],
-      matchDepNames: ["xenoterracide/**"],
       branchTopic: "{{{packageFile}}}-{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
-      pinDigests: true,
     },
     {
       // Run every Wednesday

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,6 @@
     {
       matchManagers: ["github-actions"],
       extends: ["helpers:pinGitHubActionDigests"],
-      branchTopic: "{{{packageFile}}}-{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
     },
     {


### PR DESCRIPTION
Consolidate GitHub Actions Renovate configuration by removing
redundant rules and simplifying the remaining configuration.

Changes:
- Remove separate xenoterracide org action pinning rule
- Remove custom extractVersion and versioning regex patterns
- Keep automerge and digest pinning for all GitHub Actions
- Simplify overall configuration structure