### PR TITLE
ci(renovate): pin xenoterracide actions to commit SHAs and downgrade errorprone

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,13 @@
     },
     {
       matchManagers: ["github-actions"],
+      automerge: true,
+    },
+    {
+      // Pin xenoterracide org actions to commit SHAs for build reproducibility
+      // Only these get digest pins; other actions get normal version tag updates
+      matchManagers: ["github-actions"],
+      matchDepNames: ["xenoterracide/**"],
       extends: ["helpers:pinGitHubActionDigests"],
       automerge: true,
     },

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@ SPDX-License-Identifier: CC0-1.0
     <guava.version>33.5.0-jre</guava.version>
     <jspecify.version>1.0.0</jspecify.version>
     <semver4j.version>6.0.0</semver4j.version>
-    <errorprone.annotations.version>2.49.0</errorprone.annotations.version>
-    <errorprone.core.version>2.49.0</errorprone.core.version>
+    <errorprone.annotations.version>2.48.0</errorprone.annotations.version>
+    <errorprone.core.version>2.48.0</errorprone.core.version>
     <nullaway.version>0.13.1</nullaway.version>
     <immutables.version>2.12.1</immutables.version>
     <picocli.version>4.7.7</picocli.version>


### PR DESCRIPTION
- Pin xenoterracide org GitHub Actions to commit SHAs for build reproducibility
- Only apply digest pinning to xenoterracide actions, not all actions
- Downgrade errorprone from 2.49.0 to 2.48.0