### PR TITLE
refactor(renovate): remove custom prBodyTemplate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,6 @@
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
   // Squash merges break subtree history
   ignorePaths: [".share/**", ".agents/**"],
-  // Remove the 'controls' section from PR body to avoid config noise in squash commits
-  prBodyTemplate: "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
   hostRules: [
     {
       hostType: "maven",


### PR DESCRIPTION
Remove the custom `prBodyTemplate` from Renovate configuration.

The template was previously used to strip the 'controls' section from PR
bodies to avoid config noise in squash commits. This is no longer needed.
