### PR TITLE
ci(renovate): simplify automerge rules and fix nodejs version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,22 +22,7 @@
   ],
   packageRules: [
     {
-      matchManagers: ["maven"],
-      matchUpdateTypes: ["major", "minor", "patch"],
-      automerge: true,
-    },
-    {
-      // Python deps via uv: Run daily at 03:00 UTC (after update-java)
-      schedule: ["* 3 * * *"],
-      matchManagers: ["pep621"],
-      automerge: true,
-    },
-    {
-      matchManagers: ["pyenv"],
-      automerge: true,
-    },
-    {
-      matchManagers: ["github-actions"],
+      matchManagers: ["asdf", "maven", "npm", "pyenv", "pep621", "github-actions"],
       automerge: true,
     },
     {
@@ -46,15 +31,6 @@
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
       extends: ["helpers:pinGitHubActionDigests"],
-      automerge: true,
-    },
-    {
-      // Run every Wednesday
-      // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
-      schedule: ["* 4 * * 3"],
-      matchManagers: ["npm", "asdf"],
-      groupName: "devDependencies",
-      matchUpdateTypes: ["minor", "patch", "pin"],
       automerge: true,
     },
   ],

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 24.15.0
+nodejs 24.14.1
 java temurin-25.0.3+9.0.LTS


### PR DESCRIPTION
Consolidate Renovate packageRules to reduce maintenance overhead and
correct the Node.js version in .tool-versions.

- Merge separate automerge rules for maven, pep621, pyenv, and
github-actions into a single rule covering all managers
- Remove the scheduled Wednesday npm/asdf devDependencies group rule
- Downgrade nodejs from 24.15.0 to 24.14.1 in .tool-versions

Co-authored-by: Kimi <kimi@moonshot.localhost>