### PR TITLE
ci: add node-cli workflow to pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,3 +11,5 @@ jobs:
     uses: xenoterracide/github/.github/workflows/license.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop
   prettier:
     uses: xenoterracide/github/.github/workflows/prettier.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop
+  node-cli:
+    uses: xenoterracide/github/.github/workflows/node-cli.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop


### PR DESCRIPTION
Adds the `node-cli` reusable workflow to the pre-commit GitHub Actions
workflow. This ensures Node.js CLI tooling is validated alongside existing
license and prettier checks.