### PR TITLE
ci: improve renovate config and split node-cli workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,8 @@
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
   // Squash merges break subtree history
   ignorePaths: [".share/**", ".agents/**"],
+  // Remove the 'controls' section from PR body to avoid config noise in squash commits
+  prBodyTemplate: "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
   hostRules: [
     {
       hostType: "maven",
@@ -31,6 +33,7 @@
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
       extends: ["helpers:pinGitHubActionDigests"],
+      branchTopic: "{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
     },
   ],

--- a/.github/workflows/devtools-regression.yml
+++ b/.github/workflows/devtools-regression.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: devtools-regression
+on: push
+permissions:
+  contents: read
+jobs:
+  node-cli:
+    uses: xenoterracide/github/.github/workflows/node-cli.yml@5da5c929b6ede492de3ddf60fb2376ca1b1c1493 # develop

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,5 +11,3 @@ jobs:
     uses: xenoterracide/github/.github/workflows/license.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop
   prettier:
     uses: xenoterracide/github/.github/workflows/prettier.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop
-  node-cli:
-    uses: xenoterracide/github/.github/workflows/node-cli.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop


### PR DESCRIPTION
- Remove 'controls' section from Renovate PR body to reduce noise in squash commits
- Pin GitHub Action digests for internal actions and add branchTopic for digest updates
- Extract node-cli job into separate devtools-regression workflow
- Downgrade Node.js from 24.16.0 to 24.14.1